### PR TITLE
fix: prevent crash when X11 focus is in transient state

### DIFF
--- a/src/handler/default.rs
+++ b/src/handler/default.rs
@@ -8,7 +8,7 @@ use evdev::InputEvent;
 use evdev::KeyCode as Key;
 use evdev::uinput::VirtualDevice;
 use lazy_static::lazy_static;
-use log::debug;
+use log::{debug, warn};
 
 use super::EventHandler;
 use crate::NAME;
@@ -483,17 +483,14 @@ impl<'a> DefaultEventHandler<'a> {
         if !s.in_.is_empty() || !s.not_in.is_empty() {
             // Reconnect
             let mut x11_client = self.x11_client.borrow_mut();
-            let wm_class;
-            match x11_client.get_focus_window_wmclass() {
-                Ok(res) => {
-                    wm_class = res;
+            let wm_class = match x11_client.get_focus_window_wmclass() {
+                Ok(res) => res,
+                Err(e) => {
+                    warn!("Failed to get focus window WM_CLASS: {}, passing key through", e);
+                    return Ok(None);
                 }
-                Err(_) => {
-                    x11_client.reconnect()?;
-                    wm_class = x11_client.get_focus_window_wmclass()?;
-                }
-            }
-            let class_name = std::str::from_utf8(wm_class.class())?.to_string();
+            };
+            let class_name = String::from_utf8_lossy(wm_class.class()).to_string();
             if !s.in_.is_empty() && !s.in_.contains(&class_name) {
                 return Ok(None);
             }

--- a/src/x11/client.rs
+++ b/src/x11/client.rs
@@ -5,6 +5,11 @@ use x11rb::properties::WmClass;
 use x11rb::protocol::xproto::ConnectionExt;
 use x11rb::rust_connection::RustConnection;
 
+/// X11 `GetInputFocus` reply uses special pseudo-values for the focus field.
+/// These are not real window IDs and cannot be queried with `GetProperty`.
+const INPUT_FOCUS_NONE: u32 = 0;
+const INPUT_FOCUS_POINTER_ROOT: u32 = 1;
+
 #[allow(dead_code)]
 pub struct X11Client {
     conn: RustConnection,
@@ -22,19 +27,23 @@ impl X11Client {
     pub fn get_focus_window_wmclass(&self) -> Result<WmClass, Box<dyn error::Error>> {
         let res = self.conn.get_input_focus()?.reply()?;
         let window = res.focus;
+        if window == INPUT_FOCUS_NONE || window == INPUT_FOCUS_POINTER_ROOT {
+            return Err(
+                format!(
+                    "focus is {} (not a real window)",
+                    if window == INPUT_FOCUS_NONE {
+                        "None"
+                    } else {
+                        "PointerRoot"
+                    }
+                )
+                .into(),
+            );
+        }
         let wm_class = WmClass::get(&self.conn, window)?.reply()?;
         if wm_class.is_none() {
             return Err("No WM_CLASS".into());
         }
         Ok(wm_class.unwrap())
-    }
-
-    pub fn reconnect(&mut self) -> Result<(), Box<dyn error::Error>> {
-        let dpy_name: Option<&str> = None;
-        let (conn, screen_num) = x11rb::connect(dpy_name)?;
-        self.conn = conn;
-        self.screen_num = screen_num;
-
-        Ok(())
     }
 }


### PR DESCRIPTION
GetInputFocus returns None (0) or PointerRoot (1) during screen lock/unlock and VT switches. These are pseudo-values, not real window IDs. Calling GetProperty on them produces BadWindow, which propagated up and crashed the process.

Changes:
- Reject focus values 0 and 1 before querying WM_CLASS
- Return Ok(None) on X11 failure so the key passes through instead of crashing or executing blindly
- Remove ineffective reconnect() retry logic
- Use from_utf8_lossy to avoid panic on invalid WM_CLASS